### PR TITLE
Broken safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,19 @@
   "scripts": {
     "test": "node node_modules/jasmine/bin/jasmine.js"
   },
+  "browserify": {
+    "transform": [
+      [
+        "babelify",
+        {
+          "presets": [
+            "es2015",
+            "react"
+          ]
+        }
+      ]
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git@github:warelab/gramene-search-client.git"

--- a/package.json
+++ b/package.json
@@ -6,19 +6,6 @@
   "scripts": {
     "test": "node node_modules/jasmine/bin/jasmine.js"
   },
-  "browserify": {
-    "transform": [
-      [
-        "babelify",
-        {
-          "presets": [
-            "es2015",
-            "react"
-          ]
-        }
-      ]
-    ]
-  },
   "repository": {
     "type": "git",
     "url": "git@github:warelab/gramene-search-client.git"

--- a/src/serverUrl.js
+++ b/src/serverUrl.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var queryString = require('query-string');
-const HARDCODED_SERVER = "http://data.gramene.org/swagger";
+var HARDCODED_SERVER = "http://data.gramene.org/swagger";
 
 function determineServerUrl(){
   var server;


### PR DESCRIPTION
Safari (correctly) fails to load anything that includes 2.6 or higher of this module because we specify a const in an ES5 strict js file. 

I considered adding a browserify babel es2015 transform in package.json but really, let's just remove the const.

This is part of the fix to warelab/gramoogle#109